### PR TITLE
Bugfix related news articles 500 error

### DIFF
--- a/lib/contentful/pages/news.ts
+++ b/lib/contentful/pages/news.ts
@@ -276,7 +276,7 @@ export async function getNewsPageSingle(slug: string, preview: boolean) {
         limit: 3
         where: { slug_not: $slug }
         order: date_DESC
-        preview: $preview
+        preview: false
       ) {
         items {
           ...RelatedArticleFragment


### PR DESCRIPTION
This fixes a bug with related news articles causing 500 errors when preview articles. related articles are now always not in preview mode to prevent articles being fetched that do not have the correct info (a missing image for example).