### PR TITLE
move email errors to error channel on slack

### DIFF
--- a/lib/resend/email.ts
+++ b/lib/resend/email.ts
@@ -74,7 +74,8 @@ export async function sendConfirmationEmail(show) {
           // send message to slack saying there was an issue sending the email
           console.log(error);
           sendSlackMessage(
-            `Failed to send email request to ${artist.name}(${artist.email}) on show *${show.title}*. ${error.name} - ${error.message}. <@U04HG3VHHEW>`
+            `Failed to send email request to ${artist.name}(${artist.email}) on show *${show.title}*. ${error.name} - ${error.message}. <@U04HG3VHHEW>`,
+            "error"
           );
         }
       }
@@ -109,7 +110,8 @@ export async function sendArtworkEmail(artist, date) {
     // send message to slack saying there was an issue sending the email
     console.log(error);
     sendSlackMessage(
-      `Failed to send artwork email to ${artist.name}(${artist.email}). ${error.name} - ${error.message}. <@U04HG3VHHEW>`
+      `Failed to send artwork email to ${artist.name}(${artist.email}). ${error.name} - ${error.message}. <@U04HG3VHHEW>`,
+      "error"
     );
   }
 }

--- a/lib/slack.ts
+++ b/lib/slack.ts
@@ -1,11 +1,15 @@
 const slackURL = process.env.SLACK_WEBHOOK_URL;
 const slackDevURL = process.env.SLACK_DEV_WEBHOOK_URL;
+const slackErrorURL = process.env.SLACK_ERROR_WEBHOOK_URL;
 
 export function sendSlackMessage(text: string, channel?: string) {
-  let url = slackURL;
-  if (channel && channel == "dev") {
-    url = slackDevURL;
-  }
+  const urlMap = {
+    error: slackErrorURL,
+    dev: slackDevURL,
+  };
+
+  const url = urlMap[channel] || slackURL;
+
   fetch(url, {
     method: "POST",
     body: JSON.stringify({

--- a/pages/api/admin/artwork-email.ts
+++ b/pages/api/admin/artwork-email.ts
@@ -42,7 +42,8 @@ export default async function handler(
               error
             );
             await sendSlackMessage(
-              `Failed to send email request to ${artist.name} (${artist.email}) for show *${show.title}*. Error: ${error.message}. <@U04HG3VHHEW>`
+              `Failed to send email request to ${artist.name} (${artist.email}) for show *${show.title}*. Error: ${error.message}. <@U04HG3VHHEW>`,
+              "error"
             );
           }
         }


### PR DESCRIPTION
This moves error message into their own slack channel as to not clutter up content channel with info that is not relevant for most people in that channel.