### PR TITLE
Feature/show at time api endpoint

### DIFF
--- a/lib/contentful/client.ts
+++ b/lib/contentful/client.ts
@@ -153,3 +153,19 @@ export async function getPastShows(
 
   return sorted.slice(skip, skip + take);
 }
+
+export async function getShowByTime(time) {
+  console.log(time);
+  const { items } = await client.getEntries<TypeShowFields>({
+    "fields.date[lte]": time,
+    "fields.dateEnd[gte]": time,
+    content_type: "show",
+    limit: 1,
+  });
+
+  const processed = (items as Entry<TypeShowFields>[]).map(
+    createPastShowSchema
+  );
+
+  return processed;
+}

--- a/pages/api/show-at-time.ts
+++ b/pages/api/show-at-time.ts
@@ -1,0 +1,30 @@
+// This API endpoint returns a show that takes place at a specific time.
+// Used to link recordings to shows in automated uploading process.
+
+import { NextApiRequest, NextApiResponse } from "next";
+import { assertError } from "ts-extras";
+import { getShowByTime } from "../../lib/contentful/client";
+import { PastShowSchema } from "../../types/shared";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<PastShowSchema[] | { message: string }>
+) {
+  try {
+    const { time } = req.query as typeof req.query & {
+      time: string;
+    };
+
+    const show = await getShowByTime(time);
+
+    res
+      .setHeader("Cache-Control", "s-maxage=1, stale-while-revalidate=59")
+      .json(show);
+  } catch (error) {
+    assertError(error);
+
+    console.log(error);
+
+    res.status(400).json({ message: error.message });
+  }
+}

--- a/pages/api/shows/by-timestamp.ts
+++ b/pages/api/shows/by-timestamp.ts
@@ -14,7 +14,7 @@ export default async function handler(
 
   if (
     !process.env.CRON_SECRET ||
-    authHeader !== `Bearer ${process.env.CRON_SECRET}`
+    authHeader !== `Bearer ${process.env.API_SECRET}`
   ) {
     return res.status(401).json({ message: "Unauthorized" });
   }


### PR DESCRIPTION
This PR adds a new api endpoints at /api/shows/by-timestamp that returns the show that took place at that timestamp. This endpoint will be used by the show processing script currently in development.