### PR TITLE
show by timestamp endpoint updates

### DIFF
--- a/lib/contentful/client.ts
+++ b/lib/contentful/client.ts
@@ -60,6 +60,7 @@ export const createPastShowSchema = (show: TypeShow): PastShowSchema => ({
   mixcloudLink: show.fields.mixcloudLink,
   coverImage: show.fields.coverImage.fields.file.url,
   genres: show.fields.genres.map((genre) => genre.fields?.name).filter(Boolean),
+  showArtwork: show.fields.socialImage?.fields.file.url,
 });
 
 export async function getPastShows(
@@ -156,7 +157,7 @@ export async function getPastShows(
 
 export async function getShowByTime(time) {
   console.log(time);
-  const { items } = await client.getEntries<TypeShowFields>({
+  const { items } = await previewClient.getEntries<TypeShowFields>({
     "fields.date[lte]": time,
     "fields.dateEnd[gte]": time,
     content_type: "show",

--- a/types/contentful.ts
+++ b/types/contentful.ts
@@ -109,6 +109,7 @@ export interface TypeShowFields {
   artists: Contentful.Entry<TypeArtistFields>[];
   genres: Contentful.Entry<TypeGenreFields>[];
   content?: CFRichTextTypes.Block | CFRichTextTypes.Inline;
+  socialImage?: Contentful.Asset;
 }
 
 export type TypeShow = Contentful.Entry<TypeShowFields>;

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -132,6 +132,7 @@ export type PastShowSchema = {
   coverImage: string;
   mixcloudLink: string;
   genres: string[];
+  showArtwork?: string;
 };
 
 export type ScheduleShow = {


### PR DESCRIPTION
This PR fixes bug in show by timestamp endpoint where it doesn't return show artwork required for sc upload. It also moves to using preview client to ensure draft shows are also returned.