### PR TITLE
Bugfix/instagram daily schedule

### DIFF
--- a/lib/contentful/calendar.ts
+++ b/lib/contentful/calendar.ts
@@ -506,6 +506,7 @@ export async function getInstaInfo() {
         items {
           title
           date
+          dateEnd
           instagramHandles
         }
       }
@@ -522,6 +523,7 @@ export async function getInstaInfo() {
     show.date = dayjs(show.date.slice(0, -1))
       // .subtract(cetAdjustment, "minutes")
       .format("HH:mm");
+    show.dateEnd = dayjs(show.dateEnd.slice(0, -1)).format("HH:mm");
     show.title = show.title.replace("|", "—");
   });
 

--- a/lib/contentful/calendar.ts
+++ b/lib/contentful/calendar.ts
@@ -487,15 +487,10 @@ function isPublished(entity) {
 
 export async function getInstaInfo() {
   const cetAdjustment = dayjs().tz("Europe/Berlin").utcOffset();
-  const start = Date.now();
   const nowUTC = dayjs.utc();
   const nowCET = nowUTC.add(cetAdjustment, "minutes");
   const startOfDay = nowCET.subtract(5, "hour").startOf("day").add(5, "hours");
   const startSchedule = startOfDay.toISOString();
-  const dayOfWeek = startOfDay.day();
-  // if (dayOfWeek == 6 || dayOfWeek == 0) {
-  //   endScheduleAdjustment = 3;
-  // }
   const endSchedule = startOfDay.add(1, "day").toISOString();
 
   const scheduleQuery = /* GraphQL */ `
@@ -524,8 +519,8 @@ export async function getInstaInfo() {
   const instaInfo = extractCollection<CalendarShow>(res, "showCollection");
 
   instaInfo.forEach((show, index) => {
-    show.date = dayjs(show.date)
-      .subtract(cetAdjustment, "minutes")
+    show.date = dayjs(show.date.slice(0, -1))
+      // .subtract(cetAdjustment, "minutes")
       .format("HH:mm");
     show.title = show.title.replace("|", "—");
   });

--- a/lib/resend/email.ts
+++ b/lib/resend/email.ts
@@ -5,13 +5,18 @@ const resend = new Resend(process.env.RESEND_API_KEY);
 import { sendSlackMessage } from "../../lib/slack";
 import dayjs from "dayjs";
 
+const replyToEmails = [
+  "leona@refugeworldwide.com",
+  "assistants@refugeworldwide.com",
+];
+
 export async function sendEmail(artist, show, severity) {
   try {
     const { data, error } = await resend.emails.send({
       from: "Refuge Worldwide <noreply@mail.refugeworldwide.com>",
       to: artist.email,
       subject: subject(severity),
-      reply_to: ["leona@refugeworldwide.com", "graeme@refugeworldwide.com"],
+      reply_to: replyToEmails,
       react: ShowSubmissionEmail({
         userName: artist.name,
         showDateStart: show.date,
@@ -46,10 +51,7 @@ export async function sendConfirmationEmail(show) {
             to: artist.email,
             subject:
               "Show confirmation - " + dayjs(show.start).format("MMM YYYY"),
-            reply_to: [
-              "leona@refugeworldwide.com",
-              "graeme@refugeworldwide.com",
-            ],
+            reply_to: replyToEmails,
             react: ShowSubmissionEmail({
               userName: artist.label,
               showDateStart: show.start,
@@ -87,8 +89,7 @@ export async function sendArtworkEmail(artist, date) {
         "Your show artwork for " + dayjs(date).format("dddd") + " is now ready",
       reply_to: [
         "leona@refugeworldwide.com",
-        "graeme@refugeworldwide.com",
-        "assistant@refugeworldwide.com",
+        "assistants@refugeworldwide.com",
         "irene@refugeworldwide.com",
       ],
       react: ShowArtworkEmail({

--- a/views/admin/calendarInsta.tsx
+++ b/views/admin/calendarInsta.tsx
@@ -58,10 +58,6 @@ export default function CalendarInsta() {
     }, 1000);
   }, [copied]);
 
-  // useEffect(() => {
-  //   onToggle(dialogOpen);
-  // }, [dialogOpen]);
-
   return (
     <Dialog.Root
       open={dialogOpen}
@@ -82,7 +78,7 @@ export default function CalendarInsta() {
                 contentEditable={true}
                 suppressContentEditableWarning={true}
               >
-                📻 {dayjs().format("dddd")}
+                📻 {dayjs().format("dddd")} (all times CET)
                 <br />
                 <br />
                 {data.map((show) => (

--- a/views/admin/calendarInsta.tsx
+++ b/views/admin/calendarInsta.tsx
@@ -91,6 +91,10 @@ export default function CalendarInsta() {
                     <br />
                   </>
                 ))}
+                <>
+                  {data[data.length - 1].dateEnd} Repeats Playlist
+                  <br />
+                </>
                 <br />
                 🎧 Listen live:
                 <br />


### PR DESCRIPTION
This fixes instagram schedule so times are always in CET no matter the users timezone and also adds repeats playlist to the end of the schedule.