### PR TITLE
Bugfix revalidate show artwork

### DIFF
--- a/pages/api/cron/artwork-email.ts
+++ b/pages/api/cron/artwork-email.ts
@@ -41,7 +41,7 @@ export default async function handler(
 
     for (const show of shows) {
       let showEmailed = false;
-      let artwork = show.showArtwork.url + "?fm=jpg";
+      let artwork = show.artwork.url + "?fm=jpg";
 
       for (const artist of show.artistsCollection.items) {
         if (artist.email && !emailedArtists.has(artist.email)) {

--- a/pages/api/revalidate/show-artwork.ts
+++ b/pages/api/revalidate/show-artwork.ts
@@ -23,7 +23,7 @@ export default async function handler(
 
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
-  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.setHeader("Access-Control-Allow-Headers", "*");
 
   // Handle preflight requests
   if (req.method === "OPTIONS") {

--- a/pages/api/revalidate/show-artwork.ts
+++ b/pages/api/revalidate/show-artwork.ts
@@ -21,6 +21,10 @@ export default async function handler(
   //   return res.status(403).json({ error: "Forbidden" });
   // }
 
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
   if (req.method === "POST") {
     try {
       const show = req.body;

--- a/pages/api/revalidate/show-artwork.ts
+++ b/pages/api/revalidate/show-artwork.ts
@@ -21,7 +21,7 @@ export default async function handler(
   //   return res.status(403).json({ error: "Forbidden" });
   // }
 
-  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Origin", "https://app.contentful.com");
   res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "*");
 

--- a/pages/api/revalidate/show-artwork.ts
+++ b/pages/api/revalidate/show-artwork.ts
@@ -25,6 +25,11 @@ export default async function handler(
   res.setHeader("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
   res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
 
+  // Handle preflight requests
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
   if (req.method === "POST") {
     try {
       const show = req.body;

--- a/pages/api/revalidate/show-artwork.ts
+++ b/pages/api/revalidate/show-artwork.ts
@@ -14,12 +14,12 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const origin = req.headers.origin;
-  const allowedOrigin = process.env.NEXT_PUBLIC_SITE_URL;
+  // const origin = req.headers.origin;
+  // const allowedOrigin = process.env.NEXT_PUBLIC_SITE_URL;
 
-  if (origin !== allowedOrigin) {
-    return res.status(403).json({ error: "Forbidden" });
-  }
+  // if (origin !== allowedOrigin) {
+  //   return res.status(403).json({ error: "Forbidden" });
+  // }
 
   if (req.method === "POST") {
     try {

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -122,7 +122,7 @@ export interface ShowInterface {
   };
   content: Content;
   status?: string;
-  showArtwork?: CoverImage;
+  artwork?: CoverImage;
 }
 
 export type PastShowSchema = {


### PR DESCRIPTION
This PR fixes revalidate show artwork by moving to an app hosted by contentful and fixing cors response for the api endpoint.