### PR TITLE
Fix image cropping

### DIFF
--- a/lib/loaders.ts
+++ b/lib/loaders.ts
@@ -2,7 +2,10 @@ import type { ImageLoader } from "next/image";
 
 const loaders: Record<string, ImageLoader> = {
   contentful: ({ src, width, quality = 75 }) => {
-    return `${src}?w=${width}&q=${quality}&fm=jpg&fl=progressive`;
+    // crop images to 16:9 aspect ratio so we don't chop any faces in half
+    const aspectRatio = 16 / 9;
+    const height = Math.round(width / aspectRatio);
+    return `${src}?w=${width}&h=${height}&q=${quality}&fm=jpg&fl=progressive&f=faces&fit=fill`;
   },
 };
 


### PR DESCRIPTION
This PR fixes image cropping of show pages to be set to 16:9 aspect ratio with a focal point set of faces using Contentfuls image API. Now means we dont need to individually crop images on contentful and makes the show images more flexible more multiple formats like show artwork.