### PR TITLE
Fix shows without cover image in archive

### DIFF
--- a/lib/contentful/pages/radio.ts
+++ b/lib/contentful/pages/radio.ts
@@ -10,16 +10,8 @@ import {
   extractCollectionItem,
   extractLinkedFromCollection,
   sort,
+  placeholderImage,
 } from "../../../util";
-
-const placeholderImage = {
-  sys: { id: "4njwdSvfwFLNoSZ6j1jE2G" },
-  title: "",
-  description: "",
-  url: "/images/placeholder.jpg",
-  width: 2000,
-  height: 1340,
-};
 
 export const RADIO_SHOWS_PAGE_SIZE = 20;
 
@@ -253,7 +245,7 @@ export async function getRelatedShows(
     "showCollection"
   );
 
-  // find a nicer way to process
+  //TODO: move to processor function.
   const processed = linkedFromShows.map((show) => ({
     id: show.sys.id,
     title: show.title,

--- a/lib/contentful/search.ts
+++ b/lib/contentful/search.ts
@@ -10,6 +10,8 @@ import { client } from "./client";
 import { previewClient } from "./client";
 import { s } from "@fullcalendar/core/internal-common";
 import { PastShowSchema } from "../../types/shared";
+import { createPastShowSchema } from "./client";
+import { placeholderImage } from "../../util";
 export interface SearchData {
   shows: PastShowSchema[];
   articles: TypeArticle[];
@@ -173,7 +175,9 @@ function parseShowToPastShowSchema(show): PastShowSchema {
     id: show.sys?.id,
     title: show.fields?.title,
     slug: show.fields?.slug,
-    coverImage: show.fields?.coverImage?.fields.file.url,
+    coverImage: show.fields.coverImage
+      ? show.fields.coverImage.fields.file.url
+      : placeholderImage.url,
     mixcloudLink: show.fields?.mixcloudLink,
     genres: show.fields.genres
       .map((genre) => genre.fields?.name)

--- a/util.ts
+++ b/util.ts
@@ -273,3 +273,12 @@ export const showArtworkURL = (
 
   return url;
 };
+
+export const placeholderImage = {
+  sys: { id: "4njwdSvfwFLNoSZ6j1jE2G" },
+  title: "",
+  description: "",
+  url: "https://images.ctfassets.net/taoiy3h84mql/4njwdSvfwFLNoSZ6j1jE2G/210230cc75460ea78c4b242d1cbdb55c/default-image.jpg",
+  width: 2000,
+  height: 1340,
+};


### PR DESCRIPTION
This fixes parsing shows in the archive that don't have a cover image. As cover image is not required field in the CMS we need to ensure we replace any missing cover images with the placeholder image.