### PR TITLE
Show name max character length

### DIFF
--- a/components/submission/showSubmissionForm.tsx
+++ b/components/submission/showSubmissionForm.tsx
@@ -33,7 +33,12 @@ const validationSchema = [
     ),
   }),
   Yup.object().shape({
-    showName: Yup.string().required("Please provide a show name"),
+    showName: Yup.string()
+      .required("Please provide a show name")
+      .max(
+        35,
+        "Show names can be max 35 characters long, if you have additional info please add it to the description."
+      ),
     genres: Yup.array()
       .of(
         Yup.object().shape({


### PR DESCRIPTION
This PR add validation to show form that show names can be max 35 characters long.

This is to ensure they can be displayed nicely on show and daily schedule artworks.