### PR TITLE
Show artwork updates

### DIFF
--- a/components/formFields/imageUploadField.tsx
+++ b/components/formFields/imageUploadField.tsx
@@ -100,7 +100,7 @@ export default function ImageUploadField({
         <span className="label-description">
           {description
             ? description
-            : "Minimum dimensions: 1000x1000px, maximum file size: 3MB."}
+            : "Minimum dimensions: 1000x1000px, maximum file size: 2MB."}
         </span>
       </label>
       <FilePond
@@ -137,8 +137,8 @@ export default function ImageUploadField({
         labelIdle='Drag & Drop your image or <span class="filepond--label-action">Browse</span>'
         acceptedFileTypes={["image/png", "image/jpeg"]}
         labelFileTypeNotAllowed="Invalid file type. Please only upload images of JPEG and PNG format"
-        maxFileSize="3MB"
-        labelMaxFileSizeExceeded="Image is too large. 3MB is the maximum file size."
+        maxFileSize="2MB"
+        labelMaxFileSizeExceeded="Image is too large. 2MB is the maximum file size."
       />
       {meta.touched && meta.error ? (
         <span className="text-red mt-2">{meta.error}</span>

--- a/pages/api/revalidate/show-artwork.ts
+++ b/pages/api/revalidate/show-artwork.ts
@@ -3,6 +3,7 @@ import { previewClient } from "../../../lib/contentful/client";
 import cloudinary from "cloudinary";
 import { showArtworkURL } from "../../../util";
 import { uploadImage, updateArtwork } from "../../../lib/contentful/management";
+import { error } from "console";
 
 cloudinary.v2.config({
   cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
@@ -68,6 +69,10 @@ export default async function handler(
 
       const showTitle = show.title.split(" | ")[0];
 
+      if (!showTitle) {
+        throw new Error("No artists listed in title after | symbol");
+      }
+
       const values = {
         image: images,
         showName: showTitle,
@@ -94,7 +99,7 @@ export default async function handler(
       res.status(200).json({ message: "Regeneration triggered successfully!" });
     } catch (error) {
       console.error("Revalidation error:", error);
-      res.status(500).json({ error: "Failed to regenerate." });
+      res.status(500).json({ error: error });
     }
   } else {
     res.status(405).json({ error: "Method not allowed." });

--- a/pages/api/revalidate/show-artwork.ts
+++ b/pages/api/revalidate/show-artwork.ts
@@ -99,7 +99,7 @@ export default async function handler(
       res.status(200).json({ message: "Regeneration triggered successfully!" });
     } catch (error) {
       console.error("Revalidation error:", error);
-      res.status(500).json({ error: error });
+      res.status(500).json({ message: error });
     }
   } else {
     res.status(405).json({ error: "Method not allowed." });


### PR DESCRIPTION
- Reduce max image size to 2MB on show submission form as larger images occasionally cause problems with the artwork regeneration.
- Throw error from show artwork regeneration if artists is undefined.