### PR TITLE
increase rate limit on resend api calls

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -65,3 +65,5 @@ export const REGEX = {
 export const ENDPOINT = `https://graphql.contentful.com/content/v1/spaces/${process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID}/environments/${process.env.NEXT_PUBLIC_CONTENTFUL_ENVIRONMENT_ID}`;
 
 export const FATHOM_SITE_ID = "WFNPQSZU";
+
+export const RESEND_RATE_LIMIT_DELAY = 1000; // 1000 milliseconds delay to respect rate limits

--- a/pages/api/cron/artwork-email.ts
+++ b/pages/api/cron/artwork-email.ts
@@ -3,9 +3,9 @@ import { sendArtworkEmail } from "../../../lib/resend/email";
 import { getUpcomingShowsByDate } from "../../../lib/contentful/pages/radio";
 import dayjs from "dayjs";
 import { sendSlackMessage } from "../../../lib/slack";
+import { RESEND_RATE_LIMIT_DELAY } from "../../../constants";
 
 const CONTENTFUL_SPACE_ID = process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID;
-const RATE_LIMIT_DELAY = 105; // 105 milliseconds delay to respect rate limits
 
 export default async function handler(
   req: NextApiRequest,
@@ -60,7 +60,7 @@ export default async function handler(
             emailedArtists.add(artist.email); // Add artist email to the set after emailing
             showEmailed = true;
             await new Promise((resolve) =>
-              setTimeout(resolve, RATE_LIMIT_DELAY)
+              setTimeout(resolve, RESEND_RATE_LIMIT_DELAY)
             ); // Respect the rate limit
           } catch (error) {
             console.error(

--- a/pages/api/cron/show-submission-email.ts
+++ b/pages/api/cron/show-submission-email.ts
@@ -5,6 +5,7 @@ import { getUpcomingShowsByDate } from "../../../lib/contentful/pages/radio";
 import { ShowInterface } from "../../../types/shared";
 import { sendSlackMessage } from "../../../lib/slack";
 import { sendEmail } from "../../../lib/resend/email";
+import { RESEND_RATE_LIMIT_DELAY } from "../../../constants";
 
 const contentfulSpaceId = process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID;
 export default async function handler(
@@ -54,8 +55,6 @@ async function sendEmails(
   shows: ShowInterface[],
   severity: "initial" | "follow-up" | "late"
 ) {
-  const delay = 105; // 105 milliseconds delay
-
   for (const show of shows) {
     let showEmailed = false;
 
@@ -63,7 +62,9 @@ async function sendEmails(
       if (artist.email) {
         await sendEmail(artist, show, severity);
         showEmailed = true;
-        await new Promise((resolve) => setTimeout(resolve, delay)); // Respect the rate limit
+        await new Promise((resolve) =>
+          setTimeout(resolve, RESEND_RATE_LIMIT_DELAY)
+        ); // Respect the rate limit
       }
     }
 


### PR DESCRIPTION
This fixes bug with hiting the rate limit on sending emails using resend api.