### PR TITLE
Links in prose regular weight

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -144,6 +144,10 @@
   .prose p {
     white-space: pre-wrap;
   }
+
+  .prose a {
+    font-weight: 300;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
This makes links in prose a regular font weight of 300, improving readability when an article has a lots of links.