### PR TITLE
Bugfix Revalidating shows and linked artists

### DIFF
--- a/pages/api/revalidate/radio.ts
+++ b/pages/api/revalidate/radio.ts
@@ -27,7 +27,7 @@ export default async function handler(
       console.log("Artist ID:", artist.sys.id);
       const artistEnriched = await client.getEntry(artist.sys.id);
       console.log("Artist Enriched:", artistEnriched);
-      const artistSlug = artistEnriched?.fields?.slug?.["en-US"];
+      const artistSlug = artistEnriched?.fields?.slug;
       console.log("Artist Slug:", artistSlug);
       if (artistSlug) {
         await res.revalidate(`/artists/${artistSlug}`);

--- a/pages/api/revalidate/radio.ts
+++ b/pages/api/revalidate/radio.ts
@@ -23,15 +23,10 @@ export default async function handler(
     await res.revalidate(`/radio`);
 
     for (const artist of artists) {
-      console.log("Revalidating artist page...");
-      console.log("Artist ID:", artist.sys.id);
       const artistEnriched = await client.getEntry(artist.sys.id);
-      console.log("Artist Enriched:", artistEnriched);
       const artistSlug = artistEnriched?.fields?.slug;
-      console.log("Artist Slug:", artistSlug);
       if (artistSlug) {
-        const result = await res.revalidate(`/artists/${artistSlug}`);
-        console.log("Revalidation result:", result);
+        await res.revalidate(`/artists/${artistSlug}`);
       }
     }
 

--- a/pages/api/revalidate/radio.ts
+++ b/pages/api/revalidate/radio.ts
@@ -10,8 +10,6 @@ export default async function handler(
   }
 
   try {
-    console.log("Revalidating radio page...");
-    console.log("Request body:", req.body);
     const id = JSON.parse(req.body)?.sys?.id;
     const slug = JSON.parse(req.body)?.fields?.slug?.["en-US"];
     const artists = JSON.parse(req.body)?.fields?.artists?.["en-US"];

--- a/pages/api/revalidate/radio.ts
+++ b/pages/api/revalidate/radio.ts
@@ -30,7 +30,8 @@ export default async function handler(
       const artistSlug = artistEnriched?.fields?.slug;
       console.log("Artist Slug:", artistSlug);
       if (artistSlug) {
-        await res.revalidate(`/artists/${artistSlug}`);
+        const result = await res.revalidate(`/artists/${artistSlug}`);
+        console.log("Revalidation result:", result);
       }
     }
 

--- a/pages/api/revalidate/radio.ts
+++ b/pages/api/revalidate/radio.ts
@@ -10,6 +10,8 @@ export default async function handler(
   }
 
   try {
+    console.log("Revalidating radio page...");
+    console.log("Request body:", req.body);
     const id = JSON.parse(req.body)?.sys?.id;
     const slug = JSON.parse(req.body)?.fields?.slug?.["en-US"];
     const artists = JSON.parse(req.body)?.fields?.artists?.["en-US"];
@@ -21,8 +23,12 @@ export default async function handler(
     await res.revalidate(`/radio`);
 
     for (const artist of artists) {
+      console.log("Revalidating artist page...");
+      console.log("Artist ID:", artist.sys.id);
       const artistEnriched = await client.getEntry(artist.sys.id);
+      console.log("Artist Enriched:", artistEnriched);
       const artistSlug = artistEnriched?.fields?.slug?.["en-US"];
+      console.log("Artist Slug:", artistSlug);
       if (artistSlug) {
         await res.revalidate(`/artists/${artistSlug}`);
       }


### PR DESCRIPTION
This PR fixes bug where artists pages did not include a newly published show without the user refreshing the page. To fix this we know revalidate all artist pages associated with a show when ISR webhook is sent to the API.