### PR TITLE
Revert API schedule header

### DIFF
--- a/hooks/useSchedule.ts
+++ b/hooks/useSchedule.ts
@@ -35,22 +35,8 @@ export default function useSchedule() {
     getSchedule,
     {
       refreshInterval: 60 * 1000,
-      refreshWhenHidden: true,
     }
   );
-
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (!document.hidden) {
-        console.log("Tab is visible");
-      }
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, []);
 
   return {
     scheduleData: data,

--- a/pages/api/schedule.ts
+++ b/pages/api/schedule.ts
@@ -102,7 +102,10 @@ export default async function handler(
 
     res
       .setHeader("Server-Timing", `schedule;dur=${duration}`)
-      .setHeader("Cache-Control", "public, s-maxage=60, must-revalidate")
+      .setHeader(
+        "Cache-Control",
+        "s-maxage=60, stale-while-revalidate=20, stale-if-error=600"
+      )
       .json(scheduleData);
   } catch (error) {
     assertError(error);


### PR DESCRIPTION
This PR reverts cache changes in the schedule API header. Initially attempting to solve issues with live now banner not updating after a tab is inactive for a long period of time. However I think that issue might be caused by supabase log in rather than the API cache settings themselves.